### PR TITLE
Fix -w functionallity

### DIFF
--- a/sterm/uart.py
+++ b/sterm/uart.py
@@ -198,9 +198,9 @@ class UART(object):
 
         if self.logfile:
             if self.uartmode == UARTMode.TEXT:
-                log.write(string)
+                self.logfile.write(string)
             else:
-                log.write(data)
+                self.logfile.write(data)
 
         return string
 


### PR DESCRIPTION
Add the missing self instance and correct the member variable name.

I've installed sterm 6.0.1 from pip but was unable to use the -w argument to log my terminal data to a file.